### PR TITLE
Remove roave/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
-        "roave/security-advisories": "dev-master",
         "roots/wordpress-no-content": "^6.6"
     },
     "autoload": {


### PR DESCRIPTION
Because of https://github.com/Roave/SecurityAdvisories/pull/132